### PR TITLE
Add cache_log_file for training &  a log refresh button on UI & also work after reconnect to SDWebUI

### DIFF
--- a/scripts/easyphoto_train.py
+++ b/scripts/easyphoto_train.py
@@ -18,6 +18,7 @@ from scripts.easyphoto_config import (id_path, user_id_outpath_samples,
                                   validation_prompt)
 from scripts.preprocess import preprocess_images
 
+DEFAULT_CACHE_LOG_FILE="train_kohya_log.txt"
 python_executable_path = sys.executable
 
 def urldownload_progressbar(url, filepath):
@@ -149,7 +150,11 @@ def easyphoto_train_forward(
         return "未能获得预处理后的metadata.jsonl，请检查训练过程。"
 
     train_kohya_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "train_kohya/train_lora.py")
-    print(train_kohya_path)
+    print("train_file_path : ", train_kohya_path)
+    
+    # extensions/sd-webui-EasyPhoto/train_kohya_log.txt, use to cache log and flush to UI
+    cache_log_file_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), DEFAULT_CACHE_LOG_FILE)
+    print("cache_log_file_path   : ", cache_log_file_path)
     if platform.system() == 'Windows':
         pwd = os.getcwd()
         dataloader_num_workers = 0 # for solve multi process bug
@@ -182,7 +187,8 @@ def easyphoto_train_forward(
             f'--template_dir={os.path.relpath(training_templates_path, pwd)}', 
             '--template_mask', 
             '--merge_best_lora_based_face_id', 
-            f'--merge_best_lora_name={user_id}', 
+            f'--merge_best_lora_name={user_id}',
+            f'--cache_log_file={cache_log_file_path}'
         ]
         try:
             subprocess.run(command, check=True)
@@ -210,7 +216,8 @@ def easyphoto_train_forward(
             --template_dir="{training_templates_path}" \
             --template_mask \
             --merge_best_lora_based_face_id \
-            --merge_best_lora_name="{user_id}"
+            --merge_best_lora_name="{user_id}" \
+            --cache_log_file="{cache_log_file_path}"
             '''
         )
     

--- a/scripts/easyphoto_ui.py
+++ b/scripts/easyphoto_ui.py
@@ -151,7 +151,7 @@ def on_ui_tabs():
                 with gr.Box():
                     gr.Markdown(
                         '''
-                        We need to train first to predict, please wait for the training to complete, thank you for your patience.
+                        We need to train first to predict, please wait for the training to complete, thank you for your patience.  
                         '''
                     )
                     output_message = gr.Markdown()


### PR DESCRIPTION
Problem & Solution: ISSUE[17](https://github.com/aigc-apps/sd-webui-EasyPhoto/issues/17)
We occasionally lose the connection between the WebUI and the backend. When we reconnect, the training interface no longer displays anything. This can lead to misunderstandings and accidental actions. Therefore, we've added this 'Refresh Log XX' button. If you're in the middle of training, clicking it will directly refresh the progress display. It can also be clicked when reconnecting.
1. add cache_log_file for train_lora.py,  record training steps in logs file, and will remove this log file after training, just for mark!
2. add UI ,Refresh xx button to access cache_log_file in 1, to display training logs.

目标解决的问题：解决 ISSUE17
我们时不时丢失了WebUI和后端的连接，当我们重连的时候，训练界面已经没有任何显示，这容易造成误解和误操作，所以我们添加这个刷新log的按钮，如果你在训练，点击可以直接刷新进度显示出来，如果是重连回来也可以点击

UI Setting and Interface(UI和操作界面)

1. NoTraining and Click Refresh
<img width="1765" alt="截屏2023-09-05 下午10 15 14" src="https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/11889926/5c359f72-e374-4189-b8bb-031e84586a3a">

2. During Training and Click Refresh
<img width="869" alt="截屏2023-09-05 下午10 26 04" src="https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/11889926/2a41dce8-1d79-4e6d-8265-af54883bdd0e">

3. Reconnect and Click Refresh
<img width="1766" alt="截屏2023-09-05 下午10 27 38" src="https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/11889926/31440e02-99d3-44fa-8ae4-a2005aa05688">


