### PR TITLE
Added strict argument to text_model.load_state_dict to proceed loading

### DIFF
--- a/scripts/train_kohya/utils/model_utils.py
+++ b/scripts/train_kohya/utils/model_utils.py
@@ -906,7 +906,7 @@ def load_models_from_stable_diffusion_checkpoint(v2, ckpt_path, device="cpu", dt
             torch_dtype="float32",
         )
         text_model = CLIPTextModel._from_config(cfg)
-        info = text_model.load_state_dict(converted_text_encoder_checkpoint)
+        info = text_model.load_state_dict(converted_text_encoder_checkpoint, strict=False)
     print("loading text encoder:", info)
 
     return text_model, vae, unet


### PR DESCRIPTION
Fix issue for loading text_model causing "RuntimeError: Error(s) in loading state_dict for CLIPTextModel"

```

{'thresholding', 'sample_max_value', 'timestep_spacing', 'dynamic_thresholding_ratio', 'prediction_type', 'variance_type', 'clip_sample_range'} was not found in config. Values will be initialized to default values.
loading u-net: <All keys matched successfully>
loading vae: <All keys matched successfully>
Traceback (most recent call last):
  File "/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/scripts/train_kohya/train_lora.py", line 1460, in <module>
    main()
  File "/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/scripts/train_kohya/utils/gpu_info.py", line 170, in wrapper
    result = func(*args, **kwargs)
  File "/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/scripts/train_kohya/train_lora.py", line 859, in main
    text_encoder, vae, unet = load_models_from_stable_diffusion_checkpoint(False, args.pretrained_model_ckpt)
  File "/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-**EasyPhoto/scripts/train_kohya/utils/model_utils.py", line 909, in load_models_from_stable_diffusion_checkpoint
    info = text_model.load_state_dict(converted_text_encoder_checkpoint)
  File "/home/richard/Developer/ai/stable-diffusion-webui/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 2041, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for CLIPTextModel:
        Unexpected key(s) in state_dict: "text_model.embeddings.position_ids".**
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/richard/Developer/ai/stable-diffusion-webui/venv/lib/python3.10/site-packages/accelerate/commands/launch.py", line 996, in <module>
    main()
  File "/home/richard/Developer/ai/stable-diffusion-webui/venv/lib/python3.10/site-packages/accelerate/commands/launch.py", line 992, in main
    launch_command(args)
  File "/home/richard/Developer/ai/stable-diffusion-webui/venv/lib/python3.10/site-packages/accelerate/commands/launch.py", line 986, in launch_command
    simple_launcher(args)
  File "/home/richard/Developer/ai/stable-diffusion-webui/venv/lib/python3.10/site-packages/accelerate/commands/launch.py", line 628, in simple_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
subprocess.CalledProcessError: Command '['/home/richard/Developer/ai/stable-diffusion-webui/venv/bin/python3', '/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/scripts/train_kohya/train_lora.py', '--pretrained_model_name_or_path=/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/models/stable-diffusion-v1-5', '--pretrained_model_ckpt=/home/richard/Developer/ai/stable-diffusion-webui/models/Stable-diffusion/Chilloutmix-Ni-pruned-fp16-fix.safetensors', '--train_data_dir=/home/richard/Developer/ai/stable-diffusion-webui/outputs/easyphoto-user-id-infos/rvl/processed_images', '--caption_column=text', '--resolution=512', '--random_flip', '--train_batch_size=1', '--gradient_accumulation_steps=4', '--dataloader_num_workers=16', '--max_train_steps=400', '--checkpointing_steps=100', '--learning_rate=0.0001', '--lr_scheduler=constant', '--lr_warmup_steps=0', '--train_text_encoder', '--seed=42', '--rank=128', '--network_alpha=64', '--validation_prompt=easyphoto_face, easyphoto, 1person', '--validation_steps=100', '--output_dir=/home/richard/Developer/ai/stable-diffusion-webui/outputs/easyphoto-user-id-infos/rvl/user_weights', '--logging_dir=/home/richard/Developer/ai/stable-diffusion-webui/outputs/easyphoto-user-id-infos/rvl/user_weights', '--enable_xformers_memory_efficient_attention', '--mixed_precision=fp16', '--template_dir=/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/models/training_templates', '--template_mask', '--merge_best_lora_based_face_id', '--merge_best_lora_name=rvl', '--cache_log_file=/home/richard/Developer/ai/stable-diffusion-webui/outputs/easyphoto-tmp/train_kohya_log.txt', '--validation']' returned non-zero exit status 1.
Error executing the command: Command '['/home/richard/Developer/ai/stable-diffusion-webui/venv/bin/python3', '-m', 'accelerate.commands.launch', '--mixed_precision=fp16', '--main_process_port=3456', '/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/scripts/train_kohya/train_lora.py', '--pretrained_model_name_or_path=/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/models/stable-diffusion-v1-5', '--pretrained_model_ckpt=/home/richard/Developer/ai/stable-diffusion-webui/models/Stable-diffusion/Chilloutmix-Ni-pruned-fp16-fix.safetensors', '--train_data_dir=/home/richard/Developer/ai/stable-diffusion-webui/outputs/easyphoto-user-id-infos/rvl/processed_images', '--caption_column=text', '--resolution=512', '--random_flip', '--train_batch_size=1', '--gradient_accumulation_steps=4', '--dataloader_num_workers=16', '--max_train_steps=400', '--checkpointing_steps=100', '--learning_rate=0.0001', '--lr_scheduler=constant', '--lr_warmup_steps=0', '--train_text_encoder', '--seed=42', '--rank=128', '--network_alpha=64', '--validation_prompt=easyphoto_face, easyphoto, 1person', '--validation_steps=100', '--output_dir=/home/richard/Developer/ai/stable-diffusion-webui/outputs/easyphoto-user-id-infos/rvl/user_weights', '--logging_dir=/home/richard/Developer/ai/stable-diffusion-webui/outputs/easyphoto-user-id-infos/rvl/user_weights', '--enable_xformers_memory_efficient_attention', '--mixed_precision=fp16', '--template_dir=/home/richard/Developer/ai/stable-diffusion-webui/extensions/sd-webui-EasyPhoto/models/training_templates', '--template_mask', '--merge_best_lora_based_face_id', '--merge_best_lora_name=rvl', '--cache_log_file=/home/richard/Developer/ai/stable-diffusion-webui/outputs/easyphoto-tmp/train_kohya_log.txt', '--validation']' returned non-zero exit status 1.

```
