### PR TITLE
fix the version of fsspec

### DIFF
--- a/install.py
+++ b/install.py
@@ -26,6 +26,11 @@ if not launch.is_installed("diffusers==0.18.2"):
     print('Installing requirements for easyphoto-webui')
     launch.run_pip("install diffusers==0.18.2", "requirements for diffusers")
 
+# Temporarily pin fsspec==2023.9.2. See https://github.com/huggingface/datasets/issues/6330 for details.
+if not launch.is_installed("fsspec==2023.9.2"):
+    print('Installing requirements for easyphoto-webui')
+    launch.run_pip("install fsspec==2023.9.2", "requirements for fsspec")
+
 if platform.system() != 'Windows':
     if not launch.is_installed("nvitop"):
         print('Installing requirements for easyphoto-webui')


### PR DESCRIPTION
The latest `fsspec` causes a bug in `datasets`. See huggingface/datasets#6330 for details.
In this PR, we fix this problem by pinning `fsspec == 2023.9.2` temporarily.