### PR TITLE
bugfix: np.float` was a deprecated in python3.11

### DIFF
--- a/scripts/psgan_utils.py
+++ b/scripts/psgan_utils.py
@@ -827,7 +827,7 @@ class PostProcess:
 
         height, width   = source.shape[:2]
         small_source    = cv2.resize(source, (self.img_size, self.img_size))
-        laplacian_diff  = source.astype(np.float) - cv2.resize(small_source, (width, height)).astype(np.float)
+        laplacian_diff  = source.astype(np.float64) - cv2.resize(small_source, (width, height)).astype(np.float64)
         result          = (cv2.resize(result, (width, height)) + laplacian_diff).round().clip(0, 255).astype(np.uint8)
         if self.denoise:
             result = cv2.fastNlMeansDenoisingColored(result)


### PR DESCRIPTION
```
ERROR:root:!!! Exception during processing !!!
ERROR:root:Traceback (most recent call last):
  File "D:\ComfyUI_windows_portable_nvidia_cu118_or_cpu11111\ComfyUI_windows_portable\ComfyUI\execution.py", line 153, in recursive_execute
    output_data, output_ui = get_output_data(obj, input_data_all)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ComfyUI_windows_portable_nvidia_cu118_or_cpu11111\ComfyUI_windows_portable\ComfyUI\execution.py", line 83, in get_output_data
    return_values = map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ComfyUI_windows_portable_nvidia_cu118_or_cpu11111\ComfyUI_windows_portable\ComfyUI\execution.py", line 76, in map_node_over_list
    results.append(getattr(obj, func)(**slice_dict(input_data_all, i)))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ComfyUI_windows_portable_nvidia_cu118_or_cpu11111\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Portrait-Maker\portrait\nodes.py", line 477, in super_makeup_transfer
    transfer_image = get_pagan_interface().transfer(resize_source_box_image, resize_makeup_box_image)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ComfyUI_windows_portable_nvidia_cu118_or_cpu11111\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Portrait-Maker\portrait\utils\psgan_utils.py", line 883, in transfer
    result = self.postprocess(source_crop, result)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ComfyUI_windows_portable_nvidia_cu118_or_cpu11111\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-Portrait-Maker\portrait\utils\psgan_utils.py", line 833, in __call__
    laplacian_diff = source.astype(np.float) - cv2.resize(small_source, (width, height)).astype(np.float)
                                   ^^^^^^^^
  File "D:\ComfyUI_windows_portable_nvidia_cu118_or_cpu11111\ComfyUI_windows_portable\ComfyUI\venv\Lib\site-packages\numpy\__init__.py", line 338, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
有同学在3.11的环境下遇到了这个错误，因为np.float已经弃用，因此改为np.float64