### PR TITLE
fix import errors in Windows & update UI notes

### DIFF
--- a/scripts/easyphoto_ui.py
+++ b/scripts/easyphoto_ui.py
@@ -409,6 +409,20 @@ def on_ui_tabs():
                             )
 
                         with gr.Row():
+                            infer_note = gr.Markdown(
+                                value = "For faster speed, keep the same with Stable Diffusion checkpoint (in the upper left corner).",
+                                visible=(sd_model_checkpoint != shared.opts.sd_model_checkpoint.split(" ")[0])
+                            )
+                        
+                            def update_infer_note(sd_model_checkpoint):
+                                # shared.opts.sd_model_checkpoint has a hash tag like "sd_xl_base_1.0.safetensors [31e35c80fc]".
+                                if sd_model_checkpoint == shared.opts.sd_model_checkpoint.split(" ")[0]:
+                                    return gr.Markdown.update(visible=False)
+                                return gr.Markdown.update(visible=True)
+                            
+                            sd_model_checkpoint.change(fn=update_infer_note, inputs=sd_model_checkpoint, outputs=[infer_note])
+
+                        with gr.Row():
                             def select_function():
                                 ids = []
                                 if os.path.exists(user_id_outpath_samples):

--- a/scripts/train_kohya/train_ddpo.py
+++ b/scripts/train_kohya/train_ddpo.py
@@ -6,6 +6,7 @@ import heapq
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import threading
 import time
@@ -32,6 +33,7 @@ from PIL import Image
 from safetensors.torch import load_file
 from transformers import CLIPTokenizer
 
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 import ddpo_pytorch.prompts
 import ddpo_pytorch.rewards
 from ddpo_pytorch.diffusers_patch.ddim_with_logprob import ddim_step_with_logprob

--- a/scripts/train_kohya/train_lora_sd_XL.py
+++ b/scripts/train_kohya/train_lora_sd_XL.py
@@ -19,6 +19,7 @@ import math
 import os
 import random
 import shutil
+import sys
 import time
 from pathlib import Path
 from typing import Dict
@@ -42,6 +43,7 @@ from packaging import version
 from torchvision import transforms
 from tqdm.auto import tqdm
 
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from utils.lora_diffusers import merge_lora_weights
 import utils.lora_utils as network_module
 


### PR DESCRIPTION
Some users encountered ModuleNotFoundError with the local package/file in windows.

![95a1b013b88c5ddb3a829859533ba4a7](https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/c9f9f32e-c9c4-4ca2-8058-4beb13ca10a0)

![aa07a25a9a550db02fe270c71b47d17f](https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/9c740475-99c1-471c-8f17-2dfec4a08110)
---
Add a note in the inference tab to alert users if they do not make the "Stable Diffusion checkpoint" the same with "The base checkpoint you use".

Before
![image](https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/c2f45896-f532-40db-ad2b-2efe2a80718a)

After
![image](https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/56ca14b3-91ed-4f5c-a205-f827cc5a4d6b)

