### PR TITLE
fix transformers_env

### DIFF
--- a/scripts/easyphoto_train.py
+++ b/scripts/easyphoto_train.py
@@ -1,4 +1,3 @@
-
 import os
 import platform
 import subprocess
@@ -188,11 +187,9 @@ def easyphoto_train_forward(
         # SDXL training requires some config files in openai/clip-vit-large-patch14 and laion/CLIP-ViT-bigG-14-laion2B-39B-b160k.
         # We provide them in extensions/sd-webui-EasyPhoto/models. Thus, we need set some environment variables for transformers.
         # if we pass `env` in subprocess.run, the environment variables in the child process will be reset and different from Web UI.
-        env = {
-            "TRANSFORMERS_OFFLINE": "1",
-            "TRANSFORMERS_CACHE": os.path.abspath(os.path.dirname(__file__)).replace("scripts", "models/stable-diffusion-xl"),
-            **os.environ.copy()
-        }
+        env = os.environ.copy()
+        env["TRANSFORMERS_OFFLINE"] = "1"
+        env["TRANSFORMERS_CACHE"] = sdxl_model_dir
     unload_models()
     if platform.system() == 'Windows':
         pwd = os.getcwd()


### PR DESCRIPTION
![image](https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/572cc54b-3ef5-40f7-ab46-d694d2b7be74)


The bug is triggered when the `TRANSFORMERS_OFFLINE` and `TRANSFORMERS_CACHE` environment variables are set in the system.
The logic needs to be handled carefully.

![image](https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/e826f2ac-2aed-4ea2-b6ed-5a939222061e)
