### PR TITLE
Features: support attribute edit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: flake8
         exclude: models/|scripts/easyphoto_utils/animatediff/|scripts/easyphoto_utils/animatediff_utils.py
-        args: ["--max-line-length=140", "--ignore=E303,E731,W191,W504,E402,E203,F541,W605,W503,E501,E712", "--exclude=__init__.py"]
+        args: ["--max-line-length=140", "--ignore=E303,E731,W191,W504,E402,E203,F541,W605,W503,E501,E712, F401", "--exclude=__init__.py"]
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:

--- a/scripts/easyphoto_config.py
+++ b/scripts/easyphoto_config.py
@@ -54,5 +54,8 @@ DEFAULT_TRYON_TEMPLATE = ["boy", "girl", "dress", "short"]
 # cloth lora
 DEFAULT_CLOTH_LORA = ["demo_black_200", "demo_white_200", "demo_purple_200", "demo_dress_200", "demo_short_200"]
 
+# sliders
+DEFAULT_SLIDERS = ["age_sd1_sliders", "smiling_sd1_sliders", "age_sdxl_sliders", "smiling_sdxl_sliders"]
+
 # ModelName
 SDXL_MODEL_NAME = "SDXL_1.0_ArienMixXL_v2.0.safetensors"

--- a/scripts/easyphoto_infer.py
+++ b/scripts/easyphoto_infer.py
@@ -280,6 +280,7 @@ def txt2img(
     animatediff_flag=False,
     animatediff_video_length=0,
     animatediff_fps=0,
+    loractl_flag=False,
 ):
     controlnet_units_list = []
 
@@ -305,6 +306,7 @@ def txt2img(
         animatediff_flag=animatediff_flag,
         animatediff_video_length=animatediff_video_length,
         animatediff_fps=animatediff_fps,
+        loractl_flag=False,
     )
 
     return image
@@ -520,6 +522,12 @@ def easyphoto_infer_forward(
     
     loractl_flag = False
     if "sliders" in additional_prompt:
+        if ("sdxl_sliders" in additional_prompt and not sdxl_pipeline_flag) or ("sd1_sliders" in additional_prompt and sdxl_pipeline_flag):
+            error_info = "The type of the stable diffusion model {} and attribute edit sliders ({}) does not match.".format(
+                sd_model_checkpoint, additional_prompt
+            )
+            ep_logger.error(error_info)
+            return error_info, [], []
         # download all sliders here.
         check_files_exists_and_download(check_hash.get("sliders", True), download_mode="sliders")
         check_hash["sliders"] = False
@@ -795,7 +803,7 @@ def easyphoto_infer_forward(
     # or do txt2img with SDXL once before img2img.
     # https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6923#issuecomment-1713104376.
     if sdxl_pipeline_flag and not sdxl_txt2img_flag:
-        txt2img([], diffusion_steps=2, do_not_save_samples=True)
+        txt2img([], diffusion_steps=3, do_not_save_samples=True)
         sdxl_txt2img_flag = True
     for index, user_id in enumerate(user_ids):
         if user_id == "none":

--- a/scripts/easyphoto_infer.py
+++ b/scripts/easyphoto_infer.py
@@ -1251,7 +1251,7 @@ def easyphoto_infer_forward(
                         input_prompt=input_prompts[index],
                         hr_scale=1.0,
                         seed=seed,
-                        sampler="DPM++ 2M SDE Karras",
+                        sampler="DPM++ 2M SDE Karras" if not lcm_accelerate else "Euler a",
                     )
                     # We only save the lora weight image in the first diffusion.
                     if loractl_flag:

--- a/scripts/easyphoto_infer.py
+++ b/scripts/easyphoto_infer.py
@@ -515,6 +515,11 @@ def easyphoto_infer_forward(
                     sd_model_checkpoint, checkpoint_type_name, user_id, lora_type_name
                 )
                 return error_info, [], []
+    
+    if "sliders" in additional_prompt:
+        # download all sliders here.
+        check_files_exists_and_download(check_hash.get("sliders", True), download_mode="sliders")
+        check_hash["sliders"] = False
 
     # update donot delete but use "none" as placeholder and will pass this face inpaint later
     passed_userid_list = []
@@ -841,7 +846,7 @@ def easyphoto_infer_forward(
             # Add the ddpo LoRA into the input prompt if available.
             lora_model_path = os.path.join(models_path, "Lora")
             if os.path.exists(os.path.join(lora_model_path, "ddpo_{}.safetensors".format(user_id))):
-                input_prompt += "<lora:ddpo_{}>".format(user_id)
+                input_prompt += "<lora:ddpo_{}>, ".format(user_id)
 
             # TODO: face_id_image_path may have to be picked with pitch yaw angle in video mode.
             if sdxl_pipeline_flag:

--- a/scripts/easyphoto_ui.py
+++ b/scripts/easyphoto_ui.py
@@ -10,6 +10,7 @@ from scripts.easyphoto_config import (
     DEFAULT_SCENE_LORA,
     DEFAULT_CLOTH_LORA,
     DEFAULT_TRYON_TEMPLATE,
+    DEFAULT_SLIDERS,
     cache_log_file_path,
     easyphoto_models_path,
     easyphoto_video_outpath_samples,
@@ -725,7 +726,7 @@ def on_ui_tabs():
 
                                 with gr.Row():
                                     attribute_edit_id = gr.Dropdown(
-                                        value="none",
+                                        value="none" + DEFAULT_SLIDERS,
                                         elem_id="dropdown",
                                         choices=["none"] + get_attribute_edit_ids(),
                                         label="Attribute Edit Sliders"

--- a/scripts/easyphoto_ui.py
+++ b/scripts/easyphoto_ui.py
@@ -726,9 +726,9 @@ def on_ui_tabs():
 
                                 with gr.Row():
                                     attribute_edit_id = gr.Dropdown(
-                                        value="none" + DEFAULT_SLIDERS,
+                                        value="none",
                                         elem_id="dropdown",
-                                        choices=["none"] + get_attribute_edit_ids(),
+                                        choices=["none"] + DEFAULT_SLIDERS,
                                         label="Attribute Edit Sliders"
                                     )
                                     attribute_edit_id_refresh = ToolButton(value="\U0001f504")

--- a/scripts/easyphoto_ui.py
+++ b/scripts/easyphoto_ui.py
@@ -21,8 +21,22 @@ from scripts.easyphoto_config import (
 from scripts.easyphoto_infer import easyphoto_infer_forward, easyphoto_video_infer_forward
 from scripts.easyphoto_train import easyphoto_train_forward
 from scripts.easyphoto_tryon_infer import easyphoto_tryon_infer_forward, easyphoto_tryon_mask_forward
-from scripts.easyphoto_utils import check_files_exists_and_download, check_id_valid, check_scene_valid, video_visible, ep_logger
+from scripts.easyphoto_utils import (
+    check_files_exists_and_download,
+    check_id_valid,
+    check_scene_valid,
+    check_loractl_conflict,
+    ep_logger,
+    get_attribute_edit_ids,
+    video_visible
+)
 from scripts.sdwebui import get_checkpoint_type, get_scene_prompt
+
+if not check_loractl_conflict():
+    from scripts.easyphoto_utils import LoraCtlScript
+else:
+    ep_logger.info("Import LoraCtlScript from sd-webui-loractl since the plugin already exists and is enabled.")
+
 
 gradio_compat = True
 
@@ -707,10 +721,34 @@ def on_ui_tabs():
                                 additional_prompt = gr.Textbox(
                                     label="Additional Prompt", lines=3, value="masterpiece, beauty", interactive=True
                                 )
-                                seed = gr.Textbox(
-                                    label="Seed",
-                                    value=-1,
-                                )
+                                seed = gr.Textbox(label="Seed", value=-1)
+
+                                with gr.Row():
+                                    attribute_edit_id = gr.Dropdown(
+                                        value="none",
+                                        elem_id="dropdown",
+                                        choices=["none"] + get_attribute_edit_ids(),
+                                        label="Attribute Edit Sliders"
+                                    )
+                                    attribute_edit_id_refresh = ToolButton(value="\U0001f504")
+                                    attribute_edit_id_refresh.click(
+                                        fn=lambda: gr.update(choices=["none"] + get_attribute_edit_ids()),
+                                        inputs=[],
+                                        outputs=[attribute_edit_id]
+                                    )
+                                    attribute_edit_id.select(
+                                        fn=lambda additional_prompt, attribute_edit_id: gr.update(
+                                            value=additional_prompt + f" <lora:{attribute_edit_id}:0@0, 0@0.2, 2@0.2, 2@1>"
+                                        ),
+                                        inputs=[additional_prompt, attribute_edit_id],
+                                        outputs=[additional_prompt]
+                                    )
+                                with gr.Row():
+                                    attribute_edit_wiki_url = "https://github.com/aigc-apps/sd-webui-EasyPhoto/wiki/Attribute-Edit"
+                                    _ = gr.Markdown(
+                                        value="**Please check the [[wiki]]({}) before using attribute edit**.".format(attribute_edit_wiki_url)
+                                    )
+
                                 with gr.Row():
                                     before_face_fusion_ratio = gr.Slider(
                                         minimum=0.2, maximum=0.8, value=0.50, step=0.05, label="Face Fusion Ratio Before"

--- a/scripts/easyphoto_utils/__init__.py
+++ b/scripts/easyphoto_utils/__init__.py
@@ -30,20 +30,6 @@ from .tryon_utils import (
 )
 
 try:
-    from .common_utils import (
-        check_files_exists_and_download,
-        check_id_valid,
-        check_scene_valid,
-        convert_to_video,
-        ep_logger,
-        get_controlnet_version,
-        get_mov_all_images,
-        modelscope_models_to_cpu,
-        modelscope_models_to_gpu,
-        switch_ms_model_cpu,
-        unload_models,
-        seed_everything,
-    )
     from .animatediff_utils import (
         AnimateDiffControl,
         AnimateDiffI2VLatent,
@@ -59,5 +45,21 @@ try:
         update_infotext,
         video_visible,
     )
+    from .common_utils import (
+        check_files_exists_and_download,
+        check_id_valid,
+        check_scene_valid,
+        convert_to_video,
+        ep_logger,
+        get_controlnet_version,
+        get_mov_all_images,
+        modelscope_models_to_cpu,
+        modelscope_models_to_gpu,
+        switch_ms_model_cpu,
+        unload_models,
+        seed_everything,
+        get_attribute_edit_ids
+    )
+    from .loractl_utils import check_loractl_conflict, LoraCtlScript
 except Exception as e:
     print(f"The file include sdwebui modules will be not include when preprocess.")

--- a/scripts/easyphoto_utils/common_utils.py
+++ b/scripts/easyphoto_utils/common_utils.py
@@ -1,3 +1,4 @@
+import copy
 import gc
 import hashlib
 import logging
@@ -16,7 +17,7 @@ from modelscope.utils.logger import get_logger as ms_get_logger
 from tqdm import tqdm
 
 import scripts.easyphoto_infer
-from scripts.easyphoto_config import data_path, easyphoto_models_path, models_path, tryon_gallery_dir
+from scripts.easyphoto_config import data_path, easyphoto_models_path, models_path, tryon_gallery_dir, DEFAULT_SLIDERS
 
 # Ms logger set
 ms_logger = ms_get_logger()
@@ -429,11 +430,12 @@ def check_scene_valid(lora_path, models_path):
 
 
 def get_attribute_edit_ids():
-    attribute_edit_ids = []
+    attribute_edit_ids = copy.deepcopy(DEFAULT_SLIDERS)
     for lora_name in os.listdir(os.path.join(models_path, "Lora")):
-        if (lora_name.endswith("sliders.safentensors") or lora_name.endswith("sliders.pt")):
-            attribute_edit_ids.append(os.path.splitext(lora_name)[0])
-    return attribute_edit_ids
+        if lora_name.endswith("sliders.safentensors") or lora_name.endswith("sliders.pt"):
+            if os.path.splitext(lora_name)[0] not in set(attribute_edit_ids):
+                attribute_edit_ids.append(os.path.splitext(lora_name)[0])
+    return sorted(attribute_edit_ids)
 
 
 def check_id_valid(user_id, user_id_outpath_samples, models_path):

--- a/scripts/easyphoto_utils/common_utils.py
+++ b/scripts/easyphoto_utils/common_utils.py
@@ -716,7 +716,7 @@ def seed_everything(seed=11):
 
 
 def get_controlnet_version() -> str:
-    """Adapte from sd-webui-controlnet/patch_version.py."""
+    """Borrowed from sd-webui-controlnet/patch_version.py."""
     version_file = "scripts/controlnet_version.py"
     version_file_path = os.path.join(controlnet_extensions_path, version_file)
     if not os.path.exists(version_file_path):

--- a/scripts/easyphoto_utils/common_utils.py
+++ b/scripts/easyphoto_utils/common_utils.py
@@ -227,6 +227,12 @@ download_urls = {
         "https://pai-vision-data-sh.oss-cn-shanghai.aliyuncs.com/aigc-data/easyphoto/tryon/cloth/demo_short/ref_image.jpg",
         "https://pai-vision-data-sh.oss-cn-shanghai.aliyuncs.com/aigc-data/easyphoto/tryon/cloth/demo_short/ref_image_mask.jpg",
     ],
+    "sliders": [
+        "https://pai-aigc-photog.oss-cn-hangzhou.aliyuncs.com/webui/sd14_sliders/smiling_sd1_sliders.pt",
+        "https://pai-aigc-photog.oss-cn-hangzhou.aliyuncs.com/webui/sd14_sliders/age_sd1_sliders.pt",
+        "https://pai-aigc-photog.oss-cn-hangzhou.aliyuncs.com/webui/xl_sliders/smiling_sdxl_sliders.pt",
+        "https://pai-aigc-photog.oss-cn-hangzhou.aliyuncs.com/webui/xl_sliders/age_sdxl_sliders.pt",
+    ],
 }
 save_filenames = {
     # The models are from civitai/6424 & civitai/118913, we saved them to oss for your convenience in downloading the models.
@@ -400,6 +406,13 @@ save_filenames = {
         os.path.join(tryon_cloth_gallery_dir, "demo_short_200.jpg"),
         os.path.join(tryon_cloth_gallery_dir, "demo_short_200_mask.jpg"),
     ],
+    # Sliders
+    "sliders": [
+        os.path.join(models_path, f"Lora/smiling_sd1_sliders.pt"),
+        os.path.join(models_path, f"Lora/age_sd1_sliders.pt"),
+        os.path.join(models_path, f"Lora/smiling_sdxl_sliders.pt"),
+        os.path.join(models_path, f"Lora/age_sdxl_sliders.pt"),
+    ],
 }
 
 
@@ -413,6 +426,14 @@ def check_scene_valid(lora_path, models_path):
     if lora_type == 4:
         return True
     return False
+
+
+def get_attribute_edit_ids():
+    attribute_edit_ids = []
+    for lora_name in os.listdir(os.path.join(models_path, "Lora")):
+        if (lora_name.endswith("sliders.safentensors") or lora_name.endswith("sliders.pt")):
+            attribute_edit_ids.append(os.path.splitext(lora_name)[0])
+    return attribute_edit_ids
 
 
 def check_id_valid(user_id, user_id_outpath_samples, models_path):

--- a/scripts/easyphoto_utils/loractl_utils.py
+++ b/scripts/easyphoto_utils/loractl_utils.py
@@ -1,0 +1,224 @@
+"""Borrowed from https://github.com/cheald/sd-webui-loractl.
+"""
+import os
+import re
+import sys
+
+import numpy as np
+from modules import extra_networks, shared
+from modules.processing import StableDiffusionProcessing
+import modules.scripts as scripts
+from scripts.easyphoto_config import data_path
+
+
+# TODO: refactor the plugin dependency.
+lora_extensions_path = os.path.join(data_path, "extensions", "Lora")
+lora_extensions_builtin_path = os.path.join(data_path, "extensions-builtin", "Lora")
+
+if os.path.exists(lora_extensions_path):
+    lora_path = lora_extensions_path
+elif os.path.exists(lora_extensions_builtin_path):
+    lora_path = lora_extensions_builtin_path
+else:
+    raise ImportError("Lora extension is not found.")
+sys.path.insert(0, lora_path)
+import extra_networks_lora
+import network
+sys.path.remove(lora_path)
+
+lora_weights = {}
+hire_fix_flag = False
+loractl_active = True if lora_path is not None else False
+
+
+def check_loractl_conflict():
+    loractl_extensions_path = os.path.join(data_path, "extensions", "sd-webui-loractl")
+    if os.path.exists(loractl_extensions_path):
+        disabled_extensions = shared.opts.data.get("disabled_extensions", [])
+        if "sd-webui-loractl" not in disabled_extensions:
+            return True
+    return False
+
+
+def reset_lora_weights():
+    global lora_weights
+    lora_weights.clear()
+
+
+def is_hire_fix():
+    return hire_fix_flag
+
+
+def set_hire_fix(value):
+    global hire_fix_flag
+    hire_fix_flag = value
+
+
+def is_active():
+    global loractl_active
+    return loractl_active
+
+
+def set_active(value):
+    global loractl_active
+    loractl_active = value
+
+
+class LoraCtlNetwork(extra_networks_lora.ExtraNetworkLora):
+    # Hijack the params parser and feed it dummy weights instead so it doesn't choke trying to
+    # parse our extended syntax
+    def activate(self, p, params_list):
+        if not is_active():
+            return super().activate(p, params_list)
+
+        # list params
+        for params in params_list:
+            assert params.items
+            name = params.positional[0]
+            if lora_weights.get(name, None) is None:
+                lora_weights[name] = params_to_weights(params)
+            # The hardcoded 1 weight is fine here, since our actual patch looks up the weights from
+            # our lora_weights dict
+            params.positional = [name, 1]
+            params.named = {}
+        return super().activate(p, params_list)
+
+
+# Modified from https://github.com/cheald/sd-webui-loractl/blob/master/loractl/lib/utils.py.
+def sorted_positions(raw_steps):
+    """Given a string like x@y,z@a, returns [[x, z], [y, a]] sorted for consumption by np.interp.
+    """
+    steps = [[float(s.strip()) for s in re.split("[@~]", x)] for x in re.split("[,;]", str(raw_steps))]
+    # If we just got a single number, just return it
+    if len(steps[0]) == 1:
+        return steps[0][0]
+
+    # Add implicit 1s to any steps which don't have a weight
+    steps = [[s[0], s[1] if len(s) == 2 else 1] for s in steps]
+
+    # Sort by index
+    steps.sort(key=lambda k: k[1])
+
+    steps = [list(v) for v in zip(*steps)]
+    return steps
+
+
+def calculate_weight(m, step, max_steps, step_offset=2):
+    if isinstance(m, list):
+        # normalize the step to 0~1
+        if m[1][-1] <= 1.0:
+            if max_steps > 0:
+                step = (step) / (max_steps - step_offset)
+            else:
+                step = 1.0
+        else:
+            step = step
+        # get value from interp between m[1]~m[0]
+        v = np.interp(step, m[1], m[0])
+        return v
+    else:
+        return m
+
+
+def params_to_weights(params):
+    weights = {"unet": None, "te": 1.0, "hrunet": None, "hrte": None}
+
+    if len(params.positional) > 1:
+        weights["te"] = sorted_positions(params.positional[1])
+
+    if len(params.positional) > 2:
+        weights["unet"] = sorted_positions(params.positional[2])
+
+    if params.named.get("te"):
+        weights["te"] = sorted_positions(params.named.get("te"))
+
+    if params.named.get("unet"):
+        weights["unet"] = sorted_positions(params.named.get("unet"))
+
+    if params.named.get("hr"):
+        weights["hrunet"] = sorted_positions(params.named.get("hr"))
+        weights["hrte"] = sorted_positions(params.named.get("hr"))
+
+    if params.named.get("hrunet"):
+        weights["hrunet"] = sorted_positions(params.named.get("hrunet"))
+
+    if params.named.get("hrte"):
+        weights["hrte"] = sorted_positions(params.named.get("hrte"))
+
+    # If unet ended up unset, then use the te value
+    weights["unet"] = weights["unet"] if weights["unet"] is not None else weights["te"]
+    # If hrunet ended up unset, use unet value
+    weights["hrunet"] = weights["hrunet"] if weights["hrunet"] is not None else weights["unet"]
+    # If hrte ended up unset, use te value
+    weights["hrte"] = weights["hrte"] if weights["hrte"] is not None else weights["te"]
+
+    return weights
+
+
+# Modified from https://github.com/cheald/sd-webui-loractl/blob/master/loractl/lib/network_patch.py.
+def get_weight(m):
+    return calculate_weight(m, shared.state.sampling_step, shared.state.sampling_steps, step_offset=2)
+
+
+def get_dynamic_te(self):
+    if self.name in lora_weights:
+        key = "te" if not is_hire_fix() else "hrte"
+        w = lora_weights[self.name]
+        return get_weight(w.get(key, self._te_multiplier))
+
+    return get_weight(self._te_multiplier)
+
+
+def get_dynamic_unet(self):
+    if self.name in lora_weights:
+        key = "unet" if not is_hire_fix() else "hrunet"
+        w = lora_weights[self.name]
+        return get_weight(w.get(key, self._unet_multiplier))
+
+    return get_weight(self._unet_multiplier)
+
+
+def set_dynamic_te(self, value):
+    self._te_multiplier = value
+
+
+def set_dynamic_unet(self, value):
+    self._unet_multiplier = value
+
+
+def apply():
+    if getattr(network.Network, "te_multiplier", None) is None:
+        network.Network.te_multiplier = property(get_dynamic_te, set_dynamic_te)
+        network.Network.unet_multiplier = property(get_dynamic_unet, set_dynamic_unet)
+
+
+# Modified from https://github.com/cheald/sd-webui-loractl/blob/master/scripts/loractl.py.
+class LoraCtlScript(scripts.Script):
+    def __init__(self):
+        self.original_network = None
+        super().__init__()
+
+
+    def title(self):
+        return "Dynamic Lora Weights"
+
+
+    def show(self, is_img2img):
+        return scripts.AlwaysVisible
+
+
+    def process(self, p: StableDiffusionProcessing, **kwargs):
+        if type(extra_networks.extra_network_registry["lora"]) != LoraCtlNetwork:
+            self.original_network = extra_networks.extra_network_registry["lora"]
+            network = LoraCtlNetwork()
+            extra_networks.register_extra_network(network)
+            extra_networks.register_extra_network_alias(network, "loractl")
+
+        apply()
+        set_hire_fix(False)
+        set_active(True)
+        reset_lora_weights()
+
+
+    def before_hr(self, p, *args):
+        set_hire_fix(True)

--- a/scripts/sdwebui.py
+++ b/scripts/sdwebui.py
@@ -325,6 +325,7 @@ def refresh_model_vae():
     refresh_vae_list()
 
 
+@switch_return_opt()
 def t2i_call(
     resize_mode=0,
     prompt="",
@@ -362,6 +363,7 @@ def t2i_call(
     animatediff_flag=False,
     animatediff_video_length=0,
     animatediff_fps=0,
+    loractl_flag=False,
 ):
     """
     Perform text-to-image generation.
@@ -403,16 +405,24 @@ def t2i_call(
         animatediff_flag (bool): Animatediff flag.
         animatediff_video_length (int): Animatediff video length.
         animatediff_fps (int): Animatediff video FPS.
+        loractl_flag (bool): Whether to append LoRA weight in all steps to `gen_image` or not.
 
     Returns:
         gen_image (Union[PIL.Image.Image, List[PIL.Image.Image]]): Generated image.
             When animatediff_flag is True, outputs is list.
             When animatediff_flag is False, outputs is PIL.Image.Image.
+            When loractl_flag is True, outputs is (PIL.Image.Image, PIL.Image.Image).
     """
     if sampler is None:
         sampler = "Euler a"
     if steps is None:
         steps = 20
+    
+    # It's useful to ensure the generated image is the first element among SD WebUI img2img api call results.
+    opts.return_mask = False
+    opts.return_mask_composite = False
+    if "control_net_no_detectmap" in shared.opts.data.keys():
+        shared.opts.data["control_net_no_detectmap"] = True
 
     # Pass sd_model to StableDiffusionProcessingTxt2Img does not work.
     # We should modify shared.opts.sd_model_checkpoint instead.
@@ -460,6 +470,10 @@ def t2i_call(
                 p_txt2img.script_args[alwayson_scripts.args_from : alwayson_scripts.args_from + len(controlnet_units)] = controlnet_units
             if alwayson_scripts.name == "animatediff_easyphoto" and animate_diff_process is not None:
                 p_txt2img.script_args[alwayson_scripts.args_from] = animate_diff_process
+            if "dynamic lora weights" in alwayson_scripts.name:
+                # All LoRAs in the additional prompt will be wrapped with LoraCtlNetwork rather than ExtraNetworkLora.
+                p_txt2img.script_args[alwayson_scripts.args_from] = True  # Enable Dynamic Lora Weights
+                p_txt2img.script_args[alwayson_scripts.args_from + 1] = loractl_flag  # Plot the LoRA weight in all steps
         else:
             if alwayson_scripts.title().lower() is None:
                 continue
@@ -467,8 +481,15 @@ def t2i_call(
                 p_txt2img.script_args[alwayson_scripts.args_from : alwayson_scripts.args_from + len(controlnet_units)] = controlnet_units
             if alwayson_scripts.title().lower() == "animatediff_easyphoto" and animate_diff_process is not None:
                 p_txt2img.script_args[alwayson_scripts.args_from] = animate_diff_process
+            if "dynamic lora weights" in alwayson_scripts.title().lower():
+                # All LoRAs in the additional prompt will be wrapped with LoraCtlNetwork rather than ExtraNetworkLora.
+                p_txt2img.script_args[alwayson_scripts.args_from] = True  # Enable Dynamic Lora Weights
+                p_txt2img.script_args[alwayson_scripts.args_from + 1] = loractl_flag  # Plot the LoRA weight in all steps
 
+    # TODO: refactor.
     processed = processing.process_images(p_txt2img)
+    if loractl_flag:
+        return (processed.images[0], processed.images[1])
     if animatediff_flag:
         opts.return_mask = before_opts
 


### PR DESCRIPTION
[sd-webui-loractl](https://github.com/cheald/sd-webui-loractl) as a bulitin extension in EP:
<img width="846" alt="image" src="https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/cd312b0d-10ee-48f2-8a33-e7076e37259b">

UI Interaction:
<img width="901" alt="image" src="https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/83a34ece-5bd9-43f1-a141-60144cf5f25e">

Since #296 is too far behind the main branch, a new PR is being opened.

1. For better compatibility and avoiding the conflict, we will use sd-webui-loractl if it is installed and enabled rather than the bulitin LoraCtlScript.
3. In EP img2img call, LoraCtlScript is fixed to be enabled.
4. Append the LoRA weight image to the generated results if using attribute edit.
5. Leave the checking of LoRA (sliders) syntax to SD WebUI and LoraCtlScript.