### PR TITLE
fix faceid UI with IP-Adapter Control & diffusers version in RL training

### DIFF
--- a/scripts/easyphoto_train.py
+++ b/scripts/easyphoto_train.py
@@ -6,7 +6,7 @@ import numpy as np
 from glob import glob
 from shutil import copyfile
 
-from modules.sd_models_config import config_sdxl
+from modules.sd_models_config import config_default, config_sdxl
 from PIL import Image, ImageOps
 
 from scripts.easyphoto_config import (
@@ -193,8 +193,8 @@ def easyphoto_train_forward(
 
     # Extra arguments to run SDXL training.
     env = None
-    if sdxl_pipeline_flag:
-        original_config = config_sdxl
+    if sdxl_pipeline_flag or enable_rl:
+        original_config = config_sdxl if sdxl_pipeline_flag else config_default
         sdxl_model_dir = os.path.abspath(os.path.dirname(__file__)).replace("scripts", "models/stable-diffusion-xl")
         pretrained_vae_model_name_or_path = os.path.join(sdxl_model_dir, "madebyollin_sdxl_vae_fp16_fix")
         # SDXL training requires some config files in openai/clip-vit-large-patch14 and laion/CLIP-ViT-bigG-14-laion2B-39B-b160k.
@@ -275,6 +275,7 @@ def easyphoto_train_forward(
                 f"--cache_log_file={cache_log_file_path}",
                 f"--pretrained_model_name_or_path={os.path.relpath(sd_save_path, pwd)}",
                 f"--pretrained_model_ckpt={os.path.relpath(webui_load_path, pwd)}",
+                f"--original_config={original_config}",
                 f"--face_lora_path={os.path.relpath(face_lora_path, pwd)}",
                 f"--sample_batch_size=4",
                 f"--sample_num_batches_per_epoch=2",
@@ -295,11 +296,11 @@ def easyphoto_train_forward(
                 f"--per_prompt_stat_tracking",
             ]
             max_rl_time = int(float(max_rl_time) * 60 * 60)
-            os.environ["MAX_RL_TIME"] = str(max_rl_time)
+            env["MAX_RL_TIME"] = str(max_rl_time)
             try:
                 print("Start RL (reinforcement learning). The max time of RL is {}.".format(max_rl_time))
                 # Since `accelerate` spawns a new process, set `timeout` in `subprocess.run` does not take effects.
-                subprocess.run(command, check=True)
+                subprocess.run(command, env=env, check=True)
             except subprocess.CalledProcessError as e:
                 print(f"Error executing the command: {e}")
             finally:
@@ -373,6 +374,7 @@ def easyphoto_train_forward(
                 f"--cache_log_file={cache_log_file_path}",
                 f"--pretrained_model_name_or_path={sd_save_path}",
                 f"--pretrained_model_ckpt={webui_load_path}",
+                f"--original_config={original_config}",
                 f"--face_lora_path={face_lora_path}",
                 f"--sample_batch_size=4",
                 f"--sample_num_batches_per_epoch=2",
@@ -393,11 +395,11 @@ def easyphoto_train_forward(
                 f"--per_prompt_stat_tracking",
             ]
             max_rl_time = int(float(max_rl_time) * 60 * 60)
-            os.environ["MAX_RL_TIME"] = str(max_rl_time)
+            env["MAX_RL_TIME"] = str(max_rl_time)
             try:
                 print("Start RL (reinforcement learning). The max time of RL is {}.".format(max_rl_time))
                 # Since `accelerate` spawns a new process, set `timeout` in `subprocess.run` does not take effects.
-                subprocess.run(command, check=True)
+                subprocess.run(command, env=env, check=True)
             except subprocess.CalledProcessError as e:
                 print(f"Error executing the command: {e}")
             finally:

--- a/scripts/easyphoto_ui.py
+++ b/scripts/easyphoto_ui.py
@@ -962,6 +962,11 @@ def on_ui_tabs():
                                         tooltip="Send image and generation parameters to tryon tab.",
                                     ),
                                 }
+                            
+                            def update_faceid(display_score, ipa_control):
+                                if display_score or ipa_control:
+                                    return [gr.update(visible=True), gr.update(visible=True)]
+                                return [gr.update(visible=False), gr.update(visible=False)]
 
                             display_button = gr.Button("Start Generation", variant="primary")
 
@@ -971,11 +976,7 @@ def on_ui_tabs():
                                 show_label=False,
                                 visible=False,
                             ).style(columns=[4], rows=[1], object_fit="contain", height="auto")
-                            # Display Face Similarity Scores if the user intend to do it.
-                            display_score.change(lambda x: face_id_text.update(visible=x), inputs=[display_score], outputs=[face_id_text])
-                            display_score.change(
-                                lambda x: face_id_outputs.update(visible=x), inputs=[display_score], outputs=[face_id_outputs]
-                            )
+                            display_score.change(update_faceid, inputs=[display_score, ipa_control], outputs=[face_id_text, face_id_outputs])
 
                             infer_progress = gr.Textbox(label="Generation Progress", value="No task currently", interactive=False)
 

--- a/scripts/train_kohya/ddpo_pytorch/diffusers_patch/ddim_with_logprob.py
+++ b/scripts/train_kohya/ddpo_pytorch/diffusers_patch/ddim_with_logprob.py
@@ -7,11 +7,18 @@
 # Copied from https://github.com/kvablack/ddpo-pytorch/blob/main/ddpo_pytorch/diffusers_patch/ddim_with_logprob.py.
 
 import math
+from packaging import version
 from typing import Optional, Tuple, Union
 
+import diffusers
 import torch
 from diffusers.schedulers.scheduling_ddim import DDIMScheduler, DDIMSchedulerOutput
-from diffusers.utils import randn_tensor
+
+# See https://github.com/huggingface/diffusers/issues/5025 for details.
+if version.parse(diffusers.__version__) > version.parse("0.20.2"):
+    from diffusers.utils.torch_utils import randn_tensor
+else:
+    from diffusers.utils import randn_tensor
 
 
 def _left_broadcast(t, shape):


### PR DESCRIPTION
This PR fixes:
1. When IP-Adapter Control and Display Face Similarity Scores are both enabled (the intended behavior), the faceid text and gallery will be invisible after clicking Display Face Similarity Scores.
<img width="1074" alt="image" src="https://github.com/aigc-apps/sd-webui-EasyPhoto/assets/30763967/a24034f8-8626-410d-a41b-78ad0a5c416d">

2. ImportError: cannot import name 'randn_tensor' from 'diffusers.utils' when RL is enabled with `diffusers>0.20.2`.

3. AttributeError: 'UNet2DConditionModel' object has no attribute 'attn_processors' when RL is enabled. It was caused by  using UNet2DConditionModel in the original ldm rather than diffusers.
