### PR TITLE
fix mp4 encoding error & add the issue template

### DIFF
--- a/.github/bug_report.yml
+++ b/.github/bug_report.yml
@@ -1,0 +1,99 @@
+# Borrowed from sd-webui-controlnet.
+name: Bug Report
+description: Create a report
+title: "[Bug]: "
+labels: ["bug-report"]
+
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered, and that it hasn't been fixed in a recent build/commit.
+      options:
+        - label: I have searched the existing issues and checked the recent builds/commits of both this extension and the webui
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Is EasyPhoto the latest version?
+      description: Please check for updates in the extensions tab and reproduce the bug with the latest version.
+      options:
+        - label: I have updated EasyPhoto to the latest version and the bug still exists.
+          required: true
+  - type: markdown
+    attributes:
+      value: |
+        *Please fill this form with as much information as possible, don't forget to fill "What OS..." and "What browsers" and *provide screenshots if possible**
+  - type: textarea
+    id: what-did
+    attributes:
+      label: What happened?
+      description: Tell us what happened in a very clear and simple way
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce the problem
+      description: Please provide us with precise step by step information on how to reproduce the bug
+      value: |
+        1. Go to .... 
+        2. Press ....
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: what-should
+    attributes:
+      label: What should have happened?
+      description: Tell what you think the normal behavior should be
+    validations:
+      required: true
+  - type: textarea
+    id: commits
+    attributes:
+      label: Commit where the problem happens
+      description: Which commit of the extension are you running on? Please include the commit of both the extension and the webui (Do not write *Latest version/repo/commit*, as this means nothing and will have changed by the time we read your issue. Rather, copy the **Commit** link at the bottom of the UI, or from the cmd/terminal if you can't launch it.)
+      value: |
+        webui: 
+        EastPhoto: 
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers do you use to access the UI ?
+      multiple: true
+      options:
+        - Mozilla Firefox
+        - Google Chrome
+        - Brave
+        - Apple Safari
+        - Microsoft Edge
+  - type: textarea
+    id: cmdargs
+    attributes:
+      label: Command Line Arguments
+      description: Are you using any launching parameters/command line arguments (modified webui-user .bat/.sh) ? If yes, please write them below. Write "No" otherwise.
+      render: Shell
+    validations:
+      required: true
+  - type: textarea
+    id: extensions
+    attributes:
+      label: List of enabled extensions
+      description: Please provide a full list of enabled extensions or screenshots of your "Extensions" tab.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console logs
+      description: Please provide full cmd/terminal logs from the moment you started UI to the end of it, after your bug happened. If it's very long, provide a link to pastebin or similar service.
+      render: Shell
+    validations:
+      required: true
+  - type: textarea
+    id: misc
+    attributes:
+      label: Additional information
+      description: Please provide us with any relevant additional info or context.

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/install.py
+++ b/install.py
@@ -74,7 +74,7 @@ if not is_installed("einops"):
     print("Installing requirements for easyphoto-webui")
     launch.run_pip("install einops", "requirements for diffusers")
 
-if not is_installed("imageio"):
+if not is_installed("imageio>=2.29.0"):
     print("Installing requirements for easyphoto-webui")
     # The '>' will be interpreted as redirection (in linux) since SD WebUI uses `shell=True` in `subprocess.run`.
     launch.run_pip("install \"imageio>=2.29.0\"", "requirements for imageio")

--- a/install.py
+++ b/install.py
@@ -74,9 +74,14 @@ if not is_installed("einops"):
     print("Installing requirements for easyphoto-webui")
     launch.run_pip("install einops", "requirements for diffusers")
 
-if not is_installed("imageio[pyav]>=2.29.0"):
+if not is_installed("imageio"):
     print("Installing requirements for easyphoto-webui")
-    launch.run_pip("install imageio[pyav]>=2.29.0", "requirements for imageio[pyav]")
+    # The '>' will be interpreted as redirection (in linux) since SD WebUI uses `shell=True` in `subprocess.run`.
+    launch.run_pip("install \"imageio>=2.29.0\"", "requirements for imageio")
+
+if not is_installed("av"):
+    print("Installing requirements for easyphoto-webui")
+    launch.run_pip("install \"imageio[pyav]\"", "requirements for av")
 
 # Temporarily pin fsspec==2023.9.2. See https://github.com/huggingface/datasets/issues/6330 for details.
 if not is_installed("fsspec==2023.9.2"):


### PR DESCRIPTION
1. #353 does not work due to the '>' will be interpreted as redirection (in linux) since SD WebUI uses `shell=True` in `subprocess.run`. Leo tested it in windows.
2. If users installed sd-webui-animatediff and saved generated results in the mp4 format, it will also cause mp4 encoding error even if using `pip install av`, as discussed in continue-revolution/sd-webui-animatediff#402.
3. Add the issue template.