### PR TITLE
fix mirco-conditioning in SDXL training

### DIFF
--- a/scripts/easyphoto_tryon_infer.py
+++ b/scripts/easyphoto_tryon_infer.py
@@ -85,7 +85,7 @@ def easyphoto_tryon_infer_forward(
     # change system ckpt if not match
     reload_sd_model_vae(sd_model_checkpoint, "vae-ft-mse-840000-ema-pruned.ckpt")
 
-    if not shared.opts.data.get("easyphoto_check_hash", True):
+    if not opts.data.get("easyphoto_check_hash", True):
         ep_logger.warning("EasyPhoto will not check model hash since the user set easyphoto_check_hash=False.")
     check_files_exists_and_download(check_hash.get("base", True), "base")
     check_files_exists_and_download(check_hash.get("add_tryon", True), "add_tryon")

--- a/scripts/train_kohya/utils/model_utils.py
+++ b/scripts/train_kohya/utils/model_utils.py
@@ -790,7 +790,7 @@ def convert_sdxl_text_encoder_2_checkpoint(checkpoint, max_length):
 
 
 # load state_dict without allocating new tensors
-def _load_state_dict_on_device(model, state_dict, device, dtype=None):
+def _load_state_dict_on_device(model, state_dict, device, dtype=None, strict=False):
     # dtype will use fp32 as default
     missing_keys = list(model.state_dict().keys() - state_dict.keys())
     unexpected_keys = list(state_dict.keys() - model.state_dict().keys())
@@ -808,7 +808,13 @@ def _load_state_dict_on_device(model, state_dict, device, dtype=None):
     if unexpected_keys:
         error_msgs.insert(0, "Unexpected key(s) in state_dict: {}. ".format(", ".join('"{}"'.format(k) for k in unexpected_keys)))
 
-    raise RuntimeError("Error(s) in loading state_dict for {}:\n\t{}".format(model.__class__.__name__, "\n\t".join(error_msgs)))
+    if strict:
+        raise RuntimeError("Error(s) in loading state_dict for {}:\n\t{}".format(model.__class__.__name__, "\n\t".join(error_msgs)))
+    else:
+        for k in list(state_dict.keys()):
+            if k not in unexpected_keys:
+                set_module_tensor_to_device(model, k, device, value=state_dict.pop(k), dtype=dtype)
+        return "Error(s) in loading state_dict for {}:\n\t{}".format(model.__class__.__name__, "\n\t".join(error_msgs))
 
 
 def load_models_from_sdxl_checkpoint(model_version, ckpt_path, map_location, dtype=None):


### PR DESCRIPTION
In the current SDXL training script, the implementation of Sec2.2 Micro-Conditioning corresponding to the original SDXL paper is wrong. It may leads to the cut-off head of generated images (especially in the scene lora training).